### PR TITLE
Allow printable characters within profile name

### DIFF
--- a/lua/url_utils.lua
+++ b/lua/url_utils.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.split_remote_url(remote_url)
     local remote_url = remote_url:gsub('http[s]+://', '')
     remote_url = remote_url:gsub('.*@', '')
-    local pattern = '([%w%p]+)[:/](%w+)/([%w%p]+)'
+    local pattern = '([%w%p]+)[:/]([%w%p]+)/([%w%p]+)'
     local base,user,repo = string.match(remote_url, pattern)
     if not base then
         print('pattern did not match')


### PR DESCRIPTION
`local pattern = '([%w%p]+)[:/](%w+)/([%w%p]+)'` this pattern of yours does not match accounts with `-` characters in the name. For instance a valid URL `https://github.com/cybertec-postgresql/pg_show_plans.git` will not match due to the dash in the profile name.